### PR TITLE
fix: specify workspace path for cargo install

### DIFF
--- a/Formula/redisctl.rb
+++ b/Formula/redisctl.rb
@@ -8,7 +8,7 @@ class Redisctl < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args
+    system "cargo", "install", "--path", "crates/redisctl", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
The formula was failing because redisctl uses a Cargo workspace, and cargo install needs the specific crate path.

## Changes
- Updated install command to use `--path crates/redisctl`

## Testing
Will test with `brew reinstall --build-from-source redisctl` after merge.