### PR TITLE
feat: add mdbook-lint formula

### DIFF
--- a/Formula/mdbook-lint.rb
+++ b/Formula/mdbook-lint.rb
@@ -1,0 +1,20 @@
+class MdbookLint < Formula
+  desc "Fast markdown linter for mdBook projects"
+  homepage "https://github.com/joshrotenberg/mdbook-lint"
+  url "https://github.com/joshrotenberg/mdbook-lint/archive/refs/tags/v0.11.7.tar.gz"
+  sha256 "59c7d26463495459ba9beadd4f419f096689f2041131eb8662e153e581c38255"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    cd "crates/mdbook-lint-cli" do
+      system "cargo", "install", *std_cargo_args
+    end
+  end
+
+  test do
+    assert_match "mdbook-lint #{version}", shell_output("#{bin}/mdbook-lint --version")
+    assert_match "MD001", shell_output("#{bin}/mdbook-lint rules")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ Brew Formulae for my stuff
 brew tap joshrotenberg/brew
 ```
 
-* [adrs](https://github.com/joshrotenberg/adrs) - Architectural Decision Record CLI
+## Available Formulas
 
-```
+### [adrs](https://github.com/joshrotenberg/adrs) - Architectural Decision Record CLI
+
+```sh
 brew install adrs
+```
+
+### [mdbook-lint](https://github.com/joshrotenberg/mdbook-lint) - Fast markdown linter for mdBook projects
+
+```sh
+brew install mdbook-lint
+```
+
+### [redisctl](https://github.com/joshrotenberg/redisctl) - Redis CLI tool
+
+```sh
+brew install redisctl
 ```


### PR DESCRIPTION
Add homebrew formula for mdbook-lint v0.11.7

Also updates README with all available formulas.

After merge, users can install with:
```sh
brew tap joshrotenberg/brew
brew install mdbook-lint
```