### PR TITLE
Add unimorph formula v0.1.0

### DIFF
--- a/Formula/unimorph.rb
+++ b/Formula/unimorph.rb
@@ -1,0 +1,20 @@
+class Unimorph < Formula
+  desc "Complete toolkit for working with UniMorph morphological data"
+  homepage "https://github.com/joshrotenberg/unimorph-rs"
+  url "https://github.com/joshrotenberg/unimorph-rs/archive/refs/tags/unimorph-cli-v0.1.0.tar.gz"
+  sha256 "638880ef07f1c76c6a6e3710c455d3a3efc4a4de1f18f5b2dc130c78de989868"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    cd "crates/unimorph-cli" do
+      system "cargo", "install", *std_cargo_args
+    end
+  end
+
+  test do
+    assert_match "unimorph #{version}", shell_output("#{bin}/unimorph --version")
+    assert_match "download", shell_output("#{bin}/unimorph --help")
+  end
+end


### PR DESCRIPTION
Adds Homebrew formula for [unimorph](https://github.com/joshrotenberg/unimorph-rs) - a Rust toolkit for working with UniMorph morphological data.

## Installation

```bash
brew tap joshrotenberg/brew
brew install unimorph
```

## Features

- Download and cache UniMorph datasets for 169+ languages
- Look up inflections and analyze surface forms
- Search with flexible filtering
- Export to TSV, JSON Lines, or Parquet
- Random sampling for ML workflows